### PR TITLE
Feature/revocation

### DIFF
--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -617,6 +617,63 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
         }
     }
+
+    @ReactMethod
+    public void buildGetRevocRegDefRequest(String submitterDid, String revocRegDefId, Promise promise) {
+        try {
+            String request = Ledger.buildGetRevocRegDefRequest(submitterDid, revocRegDefId).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void parseGetRevocRegDefResponse(String response, Promise promise) {
+        try{
+            LedgerResults.ParseResponseResult ledgerResult = Ledger.parseGetRevocRegDefResponse(response).get();
+            WritableArray result = new WritableNativeArray();
+            result.pushString(ledgerResult.getId());
+            result.pushString(ledgerResult.getObjectJson());
+            promise.resolve(result);
+        } catch(Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void buildGetRevocRegDeltaRequest(
+        String submitterDid,
+        String revocRegDefId,
+        int from,
+        int to,
+        Promise promise
+    ){
+        try{
+            String request = Ledger.buildGetRevocRegDeltaRequest(submitterDid,revocRegDefId,from,to).get();
+            promise.resolve(request);
+        }catch(Exception e) { 
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void parseGetRevocRegDeltaResponse(String getRevocRegDeltaResponse, Promise promise){
+        try{
+            LedgerResults.ParseRegistryResponseResult ledgerResult = Ledger.parseGetRevocRegDeltaResponse(getRevocRegDeltaResponse).get();
+            WritableArray result = new WritableNativeArray();
+            result.pushString(ledgerResult.getId());
+            result.pushString(ledgerResult.getObjectJson());
+            result.pushInt((int) ledgerResult.getTimestamp());
+            promise.resolve(result);
+        }catch(Exception e){
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
     
     // anoncreds
 
@@ -843,6 +900,24 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             promise.resolve(verified);
         }
         catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void createRevocationState(
+        int blobStorageReaderHandle,
+        String revRegDef,
+        String revRegDelta,
+        int timestamp,
+        String credRevId,
+        Promise promise
+    ){
+        try{
+            String result = Anoncreds.createRevocationState(blobStorageReaderHandle,revRegDef,revRegDelta,timestamp,credRevId).get();
+            promise.resolve(result);
+        }catch(Exception e){
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
             promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
         }

--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -564,61 +564,6 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void buildGetAttribRequest(String submitterDid, String targetDid, String raw, String hash, String enc, Promise promise) {
-        try {
-            String request = Ledger.buildGetAttribRequest(submitterDid, targetDid, raw, hash, enc).get();
-            promise.resolve(request);
-        } catch (Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-
-    @ReactMethod
-    public void buildGetNymRequest(String submitterDid, String targetDid, Promise promise) {
-        try {
-            String request = Ledger.buildGetNymRequest(submitterDid, targetDid).get();
-            promise.resolve(request);
-        } catch (Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-
-    @ReactMethod
-    public void parseGetNymResponse(String response, Promise promise) {
-        try {
-            String parsedResponse = Ledger.parseGetNymResponse(response).get();
-            promise.resolve(parsedResponse);
-        } catch (Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-
-    @ReactMethod
-    public void appendTxnAuthorAgreementAcceptanceToRequest(String requestJson, String text, String version, String taaDigest, String mechanism, int time, Promise promise) {
-        try {
-            String request = Ledger.appendTxnAuthorAgreementAcceptanceToRequest(requestJson, text, version, taaDigest, mechanism, time).get();
-            promise.resolve(request);
-        } catch (Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-
-    @ReactMethod
-    public void buildGetTxnAuthorAgreementRequest(String submitterDid, String data, Promise promise) {
-        try {
-            String request = Ledger.buildGetTxnAuthorAgreementRequest(submitterDid, data).get();
-            promise.resolve(request);
-        } catch (Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-
-    @ReactMethod
     public void buildGetRevocRegDefRequest(String submitterDid, String revocRegDefId, Promise promise) {
         try {
             String request = Ledger.buildGetRevocRegDefRequest(submitterDid, revocRegDefId).get();
@@ -674,6 +619,62 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
         }
     }
+
+    @ReactMethod
+    public void buildGetAttribRequest(String submitterDid, String targetDid, String raw, String hash, String enc, Promise promise) {
+        try {
+            String request = Ledger.buildGetAttribRequest(submitterDid, targetDid, raw, hash, enc).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void buildGetNymRequest(String submitterDid, String targetDid, Promise promise) {
+        try {
+            String request = Ledger.buildGetNymRequest(submitterDid, targetDid).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void parseGetNymResponse(String response, Promise promise) {
+        try {
+            String parsedResponse = Ledger.parseGetNymResponse(response).get();
+            promise.resolve(parsedResponse);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void appendTxnAuthorAgreementAcceptanceToRequest(String requestJson, String text, String version, String taaDigest, String mechanism, int time, Promise promise) {
+        try {
+            String request = Ledger.appendTxnAuthorAgreementAcceptanceToRequest(requestJson, text, version, taaDigest, mechanism, time).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void buildGetTxnAuthorAgreementRequest(String submitterDid, String data, Promise promise) {
+        try {
+            String request = Ledger.buildGetTxnAuthorAgreementRequest(submitterDid, data).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
     
     // anoncreds
 

--- a/ios/IndySdk.m
+++ b/ios/IndySdk.m
@@ -176,6 +176,22 @@ RCT_EXTERN_METHOD(parseGetCredDefResponse: (NSString *)getCredDefResponse
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(buildGetRevocRegDefRequest: (NSString *)submitterDid id:(NSString *)id
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(parseGetRevocRegDefResponse: (NSString *)getCredDefResponse
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(buildGetRevocRegDeltaRequest: (NSString *)submitterDid id:(NSString *)id from:(nonnull NSNumber *)from to:(nonnull NSNumber *)to
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(parseGetRevocRegDeltaResponse: (NSString *)getRevocRegDeltaResponse
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(buildGetAttribRequest: (nullable NSString *)submitterDid
                   targetDid:(NSString *)targetDid
                   raw:(nullable NSString *)raw
@@ -267,6 +283,14 @@ RCT_EXTERN_METHOD(verifierVerifyProof: (NSString *)proofReqJSON
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(createRevocationState: (nonnull NSNumber *)blobStorageReaderHandle
+                  revRegDef:(NSString *)revRegDef
+                  revRegDelta:(NSString *)revRegDelta
+                  timestamp:(nonnull NSNumber *)timestamp
+                  credRevId:(NSString *)credRevId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // non_secrets
 RCT_EXTERN_METHOD(addWalletRecord: (nonnull NSNumber *)wh
                   type: (NSString *)type
@@ -340,6 +364,13 @@ RCT_EXTERN_METHOD(fetchWalletSearchNextRecords: (nonnull NSNumber *)wh
                   )
 
 RCT_EXTERN_METHOD(closeWalletSearch: (nonnull NSNumber *)sh
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  )
+
+// Blob Storage
+RCT_EXTERN_METHOD(openBlobStorageReader: (NSString *)type
+                  config: (NSString *)config
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
                   )

--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -301,6 +301,40 @@ class IndySdk : NSObject {
                                        rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       IndyLedger.parseGetCredDefResponse(getCredDefResponse, completion: completionWithStringPair(resolve, reject))
     }
+
+    @objc func buildGetRevocRegDefRequest(_ submitterDid: String, id: String,
+                                      resolver resolve: @escaping RCTPromiseResolveBlock,
+                                      rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      IndyLedger.buildGetRevocRegDefRequest(
+        withSubmitterDid: !submitterDid.isEmpty ? submitterDid : nil,
+        id: id,
+        completion: completionWithString(resolve, reject)
+      )
+    }
+    
+    @objc func parseGetRevocRegDefResponse(_ getRevocRegDefResponse: String,
+                                       resolver resolve: @escaping RCTPromiseResolveBlock,
+                                       rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      IndyLedger.parseGetRevocRegDefResponse(getRevocRegDefResponse, completion: completionWithStringPair(resolve, reject))
+    }
+    
+    @objc func buildGetRevocRegDeltaRequest(_ submitterDid: String, id: String, from: NSNumber, to: NSNumber,
+                                      resolver resolve: @escaping RCTPromiseResolveBlock,
+                                      rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      IndyLedger.buildGetRevocRegDeltaRequest(
+        withSubmitterDid: !submitterDid.isEmpty ? submitterDid : nil,
+        revocRegDefId: id,
+        from: from,
+        to: to,
+        completion: completionWithString(resolve, reject)
+      )
+    }
+    
+    @objc func parseGetRevocRegDeltaResponse(_ getRevocRegDeltaResponse: String,
+                                       resolver resolve: @escaping RCTPromiseResolveBlock,
+                                       rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      IndyLedger.parseGetRevocRegDeltaResponse(getRevocRegDeltaResponse, completion: completionWithStringPairAndNumber(resolve, reject))
+    }
     
     @objc func buildGetAttribRequest(_ submitterDid: String?,
                                     targetDid: String,
@@ -440,6 +474,19 @@ class IndySdk : NSObject {
       )
     }
 
+    @objc func createRevocationState(_ blobStorageReaderHandle: NSNumber, revRegDef: String, revRegDelta: String, timestamp: NSNumber, credRevId: String, 
+                                              resolver resolve: @escaping RCTPromiseResolveBlock,
+                                              rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      IndyAnoncreds.createRevocationState(
+        forCredRevID: credRevId,
+        timestamp: timestamp,
+        revRegDefJSON: revRegDef,
+        revRegDeltaJSON: revRegDelta,
+        blobStorageReaderHandle: blobStorageReaderHandle,
+        completion: completionWithString(resolve, reject)
+      )
+    }
+
     // non_secret
     
     @objc func addWalletRecord(_ wh: NSNumber, type: String, id: String, value: String, tags: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
@@ -492,6 +539,14 @@ class IndySdk : NSObject {
         let shNumber:Int32 = Int32(truncating: sh)
         IndyNonSecrets.closeSearch(withHandle: shNumber, completion: completion(resolve, reject))
     }
+
+
+    // Blob Storage
+
+    @objc func openBlobStorageReader(_ type: String, config: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        IndyBlobStorage.openReader(withType: type, config: config, completion: completionWithNumber(resolve, reject))
+    }
+
     
     // completion functions
     
@@ -610,10 +665,38 @@ class IndySdk : NSObject {
       
       return completion
     }
+
+    func completionWithStringPairAndNumber(_ resolve: @escaping RCTPromiseResolveBlock,
+                                  _ reject: @escaping RCTPromiseRejectBlock) -> (_ error: Error?, _ string1: String?, _ string2: String?, _ number1: NSNumber?) -> Void {
+      func completion(error: Error?,  string1: String?, string2: String?, number1: NSNumber?) -> Void {
+        let code = (error! as NSError).code
+        if code != 0 {
+          reject("\(code)", createJsonError(error!, code), error)
+        } else {
+          resolve([string1, string2, number1])
+        }
+      }
+      
+      return completion
+    }
     
     func completionWithString(_ resolve: @escaping RCTPromiseResolveBlock,
                               _ reject: @escaping RCTPromiseRejectBlock) -> (_ error: Error?, _ result: String?) -> Void {
       func completion(error: Error?,  result: String?) -> Void {
+        let code = (error! as NSError).code
+        if code != 0 {
+          reject("\(code)", createJsonError(error!, code), error)
+        } else {
+          resolve(result)
+        }
+      }
+      
+      return completion
+    }
+    
+    func completionWithNumber(_ resolve: @escaping RCTPromiseResolveBlock,
+                              _ reject: @escaping RCTPromiseRejectBlock) -> (_ error: Error?, _ result: NSNumber?) -> Void {
+      func completion(error: Error?,  result: NSNumber?) -> Void {
         let code = (error! as NSError).code
         if code != 0 {
           reject("\(code)", createJsonError(error!, code), error)

--- a/src/index.js
+++ b/src/index.js
@@ -230,6 +230,20 @@ export type RevRegDef = {}
 
 export type RevRegId = string
 export type CredRevocId = string
+export type RevocRegDef = {
+  id: RevRegId;
+  revocDefType: 'CL_ACCUM';
+  tag: string;
+  credDefId: CredDefId;
+  value: {
+      issuanceType: 'ISSUANCE_BY_DEFAULT' | 'ISSUANCE_ON_DEMAND';
+      maxCredNum: number;
+      tailsHash: string;
+      tailsLocation: string;
+      publicKeys: string[];
+  };
+  ver: string;
+}
 export type RevocRegDelta = Record<string, unknown>
 export type TailsWriterConfig = {
   base_dir: string,
@@ -511,7 +525,7 @@ const indy = {
     return JSON.parse(await IndySdk.buildGetRevocRegDefRequest(submitterDid, revocRegDefId))
   },
 
-  async parseGetRevocRegDefResponse(getRevocRegResponse: LedgerRequestResult): Promise<GetRevocRegDefResponse> {
+  async parseGetRevocRegDefResponse(getRevocRegResponse: LedgerRequestResult): Promise<[RevRegId, RevRegDef]> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
@@ -531,7 +545,7 @@ const indy = {
     return JSON.parse(await IndySdk.buildGetRevocRegDeltaRequest(submitterDid, revocRegDefId, from, to))
   },
 
-  async parseGetRevocRegDeltaResponse(getRevocRegDeltaResponse: string): Promise<[string, object]> {
+  async parseGetRevocRegDeltaResponse(getRevocRegDeltaResponse: string): Promise<[RevRegId, RevocRegDelta, number]> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -519,16 +519,10 @@ const indy = {
   },
 
   async buildGetRevocRegDefRequest(submitterDid: Did | null, revocRegDefId: string): Promise<LedgerRequest> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     return JSON.parse(await IndySdk.buildGetRevocRegDefRequest(submitterDid, revocRegDefId))
   },
 
   async parseGetRevocRegDefResponse(getRevocRegResponse: LedgerRequestResult): Promise<[RevRegId, RevRegDef]> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     const [revocRegDefId, revocRegDef] = await IndySdk.parseGetRevocRegDefResponse(JSON.stringify(getRevocRegResponse))
     return [revocRegDefId, JSON.parse(revocRegDef)]
   },
@@ -539,16 +533,10 @@ const indy = {
     from: number = 0,
     to: number = new Date().getTime()
   ): Promise<LedgerRequest> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     return JSON.parse(await IndySdk.buildGetRevocRegDeltaRequest(submitterDid, revocRegDefId, from, to))
   },
 
   async parseGetRevocRegDeltaResponse(getRevocRegDeltaResponse: string): Promise<[RevRegId, RevocRegDelta, number]> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     const [revocRegId, revocRegDelta, timestamp] = await IndySdk.parseGetRevocRegDeltaResponse(
       JSON.stringify(getRevocRegDeltaResponse)
     )
@@ -861,9 +849,6 @@ const indy = {
     timestamp: number,
     credRevId: string
   ): Promise<any> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     return JSON.parse(
       await IndySdk.createRevocationState(blobStorageReaderHandle, revRegDef, revRegDelta, timestamp, credRevId)
     )
@@ -872,10 +857,6 @@ const indy = {
   // blob_storage
 
   async openBlobStorageReader(type: string, tailsWriterConfig: TailsWriterConfig): Promise<BlobReaderHandle> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
-
     return JSON.parse(await IndySdk.openBlobStorageReader(type, JSON.stringify(tailsWriterConfig)))
   },
 }

--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,11 @@ export type CredentialDefs = {
  *    },
  *  }
  */
-export type RevStates = {}
+export type RevStates = {
+  [key: string]: {
+    [key: string]: unknown
+  }
+}
 
 /**
  * Json - Request data json
@@ -500,6 +504,43 @@ const indy = {
     return [credDefId, JSON.parse(credDef)]
   },
 
+  async buildGetRevocRegDefRequest(submitterDid: Did | null, revocRegDefId: string): Promise<LedgerRequest> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    return JSON.parse(await IndySdk.buildGetRevocRegDefRequest(submitterDid, revocRegDefId))
+  },
+
+  async parseGetRevocRegDefResponse(getRevocRegResponse: LedgerRequestResult): Promise<GetRevocRegDefResponse> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    const [revocRegDefId, revocRegDef] = await IndySdk.parseGetRevocRegDefResponse(JSON.stringify(getRevocRegResponse))
+    return [revocRegDefId, JSON.parse(revocRegDef)]
+  },
+
+  async buildGetRevocRegDeltaRequest(
+    submitterDid: Did | null,
+    revocRegDefId: string,
+    from: number = 0,
+    to: number = new Date().getTime()
+  ): Promise<LedgerRequest> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    return JSON.parse(await IndySdk.buildGetRevocRegDeltaRequest(submitterDid, revocRegDefId, from, to))
+  },
+
+  async parseGetRevocRegDeltaResponse(getRevocRegDeltaResponse: string): Promise<[string, object]> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    const [revocRegId, revocRegDelta, timestamp] = await IndySdk.parseGetRevocRegDeltaResponse(
+      JSON.stringify(getRevocRegDeltaResponse)
+    )
+    return [revocRegId, JSON.parse(revocRegDelta), timestamp]
+  },
+
   async proverCreateMasterSecret(wh: WalletHandle, masterSecretId: ?MasterSecretId): Promise<MasterSecretId> {
     if (Platform.OS === 'ios') {
       return IndySdk.proverCreateMasterSecret(masterSecretId, wh)
@@ -797,6 +838,21 @@ const indy = {
       blobStorageReaderHandle
     )
     return [JSON.parse(credJson), revocId, JSON.parse(revocRegDelta)]
+  },
+
+  async createRevocationState(
+    blobStorageReaderHandle: BlobReaderHandle,
+    revRegDef: string,
+    revRegDelta: string,
+    timestamp: number,
+    credRevId: string
+  ): Promise<any> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    return JSON.parse(
+      await IndySdk.createRevocationState(blobStorageReaderHandle, revRegDef, revRegDelta, timestamp, credRevId)
+    )
   },
 
   // blob_storage

--- a/src/index.js
+++ b/src/index.js
@@ -191,8 +191,8 @@ export type CredentialDefs = {
  */
 export type RevStates = {
   [key: string]: {
-    [key: string]: unknown
-  }
+    [key: string]: unknown,
+  },
 }
 
 /**
@@ -231,18 +231,18 @@ export type RevRegDef = {}
 export type RevRegId = string
 export type CredRevocId = string
 export type RevocRegDef = {
-  id: RevRegId;
-  revocDefType: 'CL_ACCUM';
-  tag: string;
-  credDefId: CredDefId;
+  id: RevRegId,
+  revocDefType: 'CL_ACCUM',
+  tag: string,
+  credDefId: CredDefId,
   value: {
-      issuanceType: 'ISSUANCE_BY_DEFAULT' | 'ISSUANCE_ON_DEMAND';
-      maxCredNum: number;
-      tailsHash: string;
-      tailsLocation: string;
-      publicKeys: string[];
-  };
-  ver: string;
+    issuanceType: 'ISSUANCE_BY_DEFAULT' | 'ISSUANCE_ON_DEMAND',
+    maxCredNum: number,
+    tailsHash: string,
+    tailsLocation: string,
+    publicKeys: string[],
+  },
+  ver: string,
 }
 export type RevocRegDelta = Record<string, unknown>
 export type TailsWriterConfig = {


### PR DESCRIPTION
Adds recipient revocation capabilities for both Android and iOS:
    buildGetRevocRegDefRequest
    parseGetRevocRegDefResponse
    buildGetRevocRegDeltaRequest
    parseGetRevocRegDeltaResponse
    createRevocationState
This is a followup to #15. @TheTreek contributed the Android portions.
This fixes the types of the previous PR and readjusted the method positioning to align with Indy.

All commits should be signed. If there's still issues the repo may be checking for GCP signed keys, not DCO signoff. 