### PR TITLE
fix: alter createrevocationstate parameters typing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -853,13 +853,19 @@ const indy = {
 
   async createRevocationState(
     blobStorageReaderHandle: BlobReaderHandle,
-    revRegDef: string,
-    revRegDelta: string,
+    revRegDef: RevocRegDef,
+    revRegDelta: RevocRegDelta,
     timestamp: number,
     credRevId: string
   ): Promise<any> {
     return JSON.parse(
-      await IndySdk.createRevocationState(blobStorageReaderHandle, revRegDef, revRegDelta, timestamp, credRevId)
+      await IndySdk.createRevocationState(
+        blobStorageReaderHandle,
+        JSON.stringify(revRegDef),
+        JSON.stringify(revRegDelta),
+        timestamp,
+        credRevId
+      )
     )
   },
 


### PR DESCRIPTION
For recipient revocation this PR adjusts the `createRevocationState()` method parameters to align better with other methods & mirror the indy node wrapper. This corresponds with a indy-sdk DefinitelyTyped fix PR (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58026).

Signed-off-by: James Ebert <jamesebert.k@gmail.com>