### PR TITLE
fix: return function of proverDeleteCredential

### DIFF
--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -420,7 +420,7 @@ class IndySdk : NSObject {
                                         resolver resolve: @escaping RCTPromiseResolveBlock,
                                         rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       let whNumber:Int32  = Int32(truncating:walletHandle)
-      IndyAnoncreds.proverDeleteCredentials(withId: credId, walletHandle: whNumber, completion: completionWithString(resolve, reject))
+      IndyAnoncreds.proverDeleteCredentials(withId: credId, walletHandle: whNumber, completion: completion(resolve, reject))
     }
     
     @objc func proverGetCredentialsForProofReq(_ proofReqJSON: String, walletHandle: NSNumber,

--- a/src/index.js
+++ b/src/index.js
@@ -619,7 +619,7 @@ const indy = {
 
   async proverDeleteCredential(wh: WalletHandle, credId: CredId): Promise<void> {
     if (Platform.OS === 'ios') {
-      return JSON.parse(await IndySdk.proverDeleteCredential(credId, wh))
+      return JSON.parse(await IndySdk.proverDeleteCredentials(credId, wh))
     }
     return JSON.parse(await IndySdk.proverDeleteCredential(wh, credId))
   },

--- a/src/index.js
+++ b/src/index.js
@@ -619,9 +619,9 @@ const indy = {
 
   async proverDeleteCredential(wh: WalletHandle, credId: CredId): Promise<void> {
     if (Platform.OS === 'ios') {
-      return JSON.parse(await IndySdk.proverDeleteCredential(credId, wh))
+      return await IndySdk.proverDeleteCredential(credId, wh)
     }
-    return JSON.parse(await IndySdk.proverDeleteCredential(wh, credId))
+    return await IndySdk.proverDeleteCredential(wh, credId)
   },
 
   // NOTE: This method is deprecated because immediately returns all fetched credentials. Use proverSearchCredentials() to fetch records by small batches.

--- a/src/index.js
+++ b/src/index.js
@@ -619,7 +619,7 @@ const indy = {
 
   async proverDeleteCredential(wh: WalletHandle, credId: CredId): Promise<void> {
     if (Platform.OS === 'ios') {
-      return JSON.parse(await IndySdk.proverDeleteCredentials(credId, wh))
+      return JSON.parse(await IndySdk.proverDeleteCredential(credId, wh))
     }
     return JSON.parse(await IndySdk.proverDeleteCredential(wh, credId))
   },


### PR DESCRIPTION
- fix: ios wrapper has a typo
- fix: removed typo in js side
- fix: do not parse the void response
- fix: void return uses completion
