### PR TITLE
feat: add generate wallet key method

### DIFF
--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -1012,6 +1012,17 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void generateWalletKey(String configJson, Promise promise) {
+        try {
+            String walletKey = Wallet.generateWalletKey(configJson).get();
+            promise.resolve(walletKey);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
     public void createRevocationState(
         int blobStorageReaderHandle,
         String revRegDef,

--- a/ios/IndySdk.m
+++ b/ios/IndySdk.m
@@ -306,6 +306,10 @@ RCT_EXTERN_METHOD(verifierVerifyProof: (NSString *)proofReqJSON
 RCT_EXTERN_METHOD(generateNonce: (RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(generateWalletKey: (NSString *) configJson
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(createRevocationState: (nonnull NSNumber *)blobStorageReaderHandle
                   revRegDef:(NSString *)revRegDef
                   revRegDelta:(NSString *)revRegDelta

--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -507,9 +507,15 @@ class IndySdk : NSObject {
       )
     }
     
-    @objc func generateNonce(_ resolve: @escaping RCTPromiseResolveBlock,
-                             rejecter reject: @escaping RCTPromiseRejectBlock) {
+    @objc func generateNonce(_ resolve: @escaping RCTPromiseResolveBlock, 
+            rejecter reject: @escaping RCTPromiseRejectBlock) {
       IndyAnoncreds.generateNonce(completionWithString(resolve, reject));
+    }
+
+    @objc func generateWalletKey(_ configJson: String,
+                             resolver resolve: @escaping RCTPromiseResolveBlock,
+                             rejecter reject: @escaping RCTPromiseRejectBlock) {
+      IndyWallet.generateKey(forConfig: configJson, completion: completionWithString(resolve, reject));
     }
 
     @objc func createRevocationState(_ blobStorageReaderHandle: NSNumber, revRegDef: String, revRegDelta: String, timestamp: NSNumber, credRevId: String, 

--- a/src/index.js
+++ b/src/index.js
@@ -750,6 +750,10 @@ const indy = {
     return IndySdk.generateNonce()
   },
 
+  async generateWalletKey(config?: { seed?: string } = {}) {
+    return IndySdk.generateWalletKey(JSON.stringify(config))
+  },
+
   async appendTxnAuthorAgreementAcceptanceToRequest(
     request: LedgerRequest,
     text: string,


### PR DESCRIPTION
Used by multitenancy. Althought multitenancy will mostly be used on the server this is added for consistency with Node.JS and making sure all methods used from indy sdk in AFJ are available here.