### PR TITLE
feat!: update iOS installation to hyperledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Add the following to `MainActivity.java`:
 import android.os.Bundle;
 import android.system.ErrnoException;
 import android.system.Os;
-import java.io.File;
 
 public class MainActivity extends ReactActivity {
   //...
@@ -123,6 +122,31 @@ public class MainActivity extends ReactActivity {
 }
 ```
 
+### 6. Hermes
+
+Hermes is required in order to perform ledger operations using the Indy SDK.
+
+> For more info, see [this Indy-SDK issue](https://github.com/hyperledger/indy-sdk/issues/2346#issuecomment-841000640).
+
+#### React Native >= 0.70.0
+
+Hermes is enabled by default
+
+#### React Native 0.62.0 - 0.69.5
+
+Add or adjust the following in the `android/app/build.gradle` to:
+
+```gradle
+project.ext.react = [
+    enableHermes: true,  // clean and rebuild if changing
+]
+```
+
+#### React Native <= 0.61.5
+
+Hermes is not required for older versions of React Native
+
+
 ## iOS
 
 1. Install CocoaPods dependencies:
@@ -134,8 +158,16 @@ pod install --project-directory=ios/
 2. Add the following line to the start of your Podfile (`ios/Podfile`):
 
 ```
-source 'https://github.com/AbsaOSS/dlt-cocoapods-specs.git'
+source 'https://github.com/hyperledger/indy-sdk-react-native'
 ```
+
+3. Configure Bitcode to `no` in both the project and targets
+
+4. Set `Build Libraries for Distribution` to `yes` in both the project and targets
+
+> This is required due to mismatching Swift versions between the Indy SDK and the application, as described in this [Stackoverflow Answer](https://stackoverflow.com/questions/58654714/module-compiled-with-swift-5-1-cannot-be-imported-by-the-swift-5-1-2-compiler/63305234#63305234)
+
+5. iOS Simulators are currently not supported and should be disabled
 
 ## Usage
 

--- a/Specs/Indy/1.15.0/Indy.podspec
+++ b/Specs/Indy/1.15.0/Indy.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+
+  s.name         = "Indy"
+  s.version      = "1.15.0"
+  s.summary      = "Indy SDK iOS Wrapper - SSI Technologies"
+  s.homepage     = "https://www.hyperledger.org/use/hyperledger-indy"
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { "Niall Shaw" => "niall.shaw@absa.africa" }
+
+  s.platform     = :ios, "10.0"
+
+  s.source       = { :http => "https://github.com/hyperledger/indy-sdk-react-native/releases/download/0.2.2/ios-indy-sdk-1.15.zip" }
+  s.framework    = "Indy"
+  s.source_files = "**/*.h"
+  s.vendored_frameworks = "IndySdk/Indy.framework"
+
+end

--- a/Specs/Indy/1.16.0/Indy.podspec
+++ b/Specs/Indy/1.16.0/Indy.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+
+  s.name         = "Indy"
+  s.version      = "1.16.0"
+  s.summary      = "Indy SDK iOS Wrapper - SSI Technologies"
+  s.homepage     = "https://www.hyperledger.org/use/hyperledger-indy"
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = { "Berend Sliedrecht" => "Berend Sliedrecht" }
+
+  s.platform     = :ios, "10.0"
+
+  s.source       = { :http => "https://github.com/hyperledger/indy-sdk-react-native/releases/download/0.2.2/ios-indy-sdk-1.16.0.zip" }
+  s.framework    = "Indy"
+  s.source_files = "**/*.h"
+  s.vendored_frameworks = "IndySdk/Indy.framework"
+
+end


### PR DESCRIPTION
This PR expands upon @niallshaw-absa's efforts in #54, and places the IndySDK framework file and podspec within this Hyperledger repo. I've left the podspec author under @niallshaw-absa, as you performed the majority of the work, but I'd be happy to change this if desired. Again, thank you to your efforts @niallshaw-absa!

Additionally, this PR updates:
* The iOS instructions to include configuring of setting the Bitcode and Build Libraries for Distribution, and notes that Simulators are currently not supported.
* The Android instructions to install Hermes and remove an unnecessary Java import.

If any testing is desired, an essentially identical setup is available using 
```
source 'https://github.com/JamesKEbert/indy-sdk-react-native'
```

I've marked this as a breaking change, as noted by @TimoGlastra in https://github.com/hyperledger/indy-sdk-react-native/pull/54#issuecomment-1217811816