### PR TITLE
build: rename android package

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -100,7 +100,7 @@ def configureReactNativePom(def pom) {
         name packageJson.title
         artifactId packageJson.name
         version = packageJson.version
-        group = "com.reactlibrary"
+        group = "org.hyperledger.indy.sdk.reactnative"
         description packageJson.description
         url packageJson.repository.baseUrl
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="org.hyperledger.indy.sdk.reactnative">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 </manifest>

--- a/android/src/main/java/org/hyperledger/indy/sdk/reactnative/IndySdkModule.java
+++ b/android/src/main/java/org/hyperledger/indy/sdk/reactnative/IndySdkModule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.reactlibrary;
+package org.hyperledger.indy.sdk.reactnative;
 
 import android.annotation.TargetApi;
 import android.util.Log;

--- a/android/src/main/java/org/hyperledger/indy/sdk/reactnative/IndySdkPackage.java
+++ b/android/src/main/java/org/hyperledger/indy/sdk/reactnative/IndySdkPackage.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.reactlibrary;
+package org.hyperledger.indy.sdk.reactnative;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
#57 
Renames android package from default `com.reactlibrary` to `org.hyperledger.indy.sdk.reactnative`

Signed-off-by: Niall Shaw <niall.shaw@absa.africa>