### PR TITLE
chore: switch iOS steps, add pod update for existing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ source 'https://github.com/hyperledger/indy-sdk-react-native'
 2. Install the Latest CocoaPods dependencies:
 
 ```
-pod install --project-directory=ios/
+cd ios
+pod install
 pod update Indy
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,16 +149,17 @@ Hermes is not required for older versions of React Native
 
 ## iOS
 
-1. Install CocoaPods dependencies:
-
-```
-pod install --project-directory=ios/
-```
-
-2. Add the following line to the start of your Podfile (`ios/Podfile`):
+1. Add the following line to the start of your Podfile (`ios/Podfile`):
 
 ```
 source 'https://github.com/hyperledger/indy-sdk-react-native'
+```
+
+2. Install the Latest CocoaPods dependencies:
+
+```
+pod install --project-directory=ios/
+pod update Indy
 ```
 
 3. Configure Bitcode to `no` in both the project and targets


### PR DESCRIPTION
I've tested the behavior from #56 and everything is working ~~as expected~~ mostly as expected, except for when installing in an existing project--the existing podfile.lock will mean 1.15.0 will continue to be installed instead of 1.16.0, even if Indy is given a specific version in the indy-sdk-react-native.podspec. Here's [info from cocoapods](https://guides.cocoapods.org/using/pod-install-vs-update.html#using-exact-versions-in-the-podfile-is-not-enough) on the issue. I've therefore added a step to do a `pod update Indy` to update to the latest version. 

Additionally, the source command should have come before the pod install from #54, so I've flipped those steps. 

Also, removed the --project-directory in place of a `cd ios` since we have two commands to run. 