### PR TITLE
docs: Add link to Android aar and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,50 +48,42 @@ allprojects {
 }
 ```
 
-### 3. Add JNA library dependency
+### 3. Download Android libindy binaries
 
-Add to `android/app/build.gradle`:
+Download Android `.aar` library from Release 0.2.2 [android-indy-sdk-release-device-1.15.0.aar](https://github.com/hyperledger/indy-sdk-react-native/releases/download/0.2.2/android-indy-sdk-release-device-1.15.0.aar) and copy it into `android/app/libs`.
+
+### 4. Update Gradle dependencies
+
+Add `.aar` to array of file dependencies and JNA library to `android/app/build.gradle`:
 
 ```groovy
 dependencies {
     // ...
-    implementation 'net.java.dev.jna:jna:5.2.0'
+
+    implementation fileTree(dir: "libs", include: ["*.jar", "*.aar"])
+    implementation 'net.java.dev.jna:jna:5.6.0'
 
     // ...
 }
 ```
 
-### 4. Add Android libindy binaries
+I also needed to the gradle file `android/app/build.gradle` the following because I was getting duplicated class error:
 
-Download Android libindy binaries and copy them into `android/app/src/main/jniLibs`.
-
-1. Create `android/app/src/main/jniLibs` directory in your project
-2. Create subdirectories `arm64-v8a`, `armeabi-v7a`, `x86` and `x86_64` inside `android/app/src/main/jniLibs`.
-3. Download the required libindy binaries for your release-channel and version
-   - with `stable` channel and version `1.16.0` base url will be https://repo.sovrin.org/android/libindy/stable/1.16.0/
-   - download the binaries for `arm64`, `armv7`, `x86` and `x86_64`, e.g.:
-     - `libindy_android_arm64_1.16.0.zip`
-     - `libindy_android_armv7_1.16.0.zip`
-     - `libindy_android_x86_1.16.0.zip`
-     - `libindy_android_x86_64_1.16.0.zip`
-4. Extract all downloaded ZIP files and copy `libindy.so` files to corresponding `jniLibs` directory
-   - `libindy_arm64/lib/libindy.so` to `jniLibs/arm64-v8a/libindy.so`
-   - `libindy_armv7/lib/libindy.so` to `jniLibs/armeabi-v7a/libindy.so`
-   - `libindy_x86/lib/libindy.so` to `jniLibs/x86/libindy.so`
-   - `libindy_x86_64/lib/libindy.so` to `jniLibs/x86_64/libindy.so`
-5. Download the required JNA binaries from the [JNA GitHub repo](https://github.com/java-native-access/jna)
-   - libindy version 1.16.0 works with version 5.5.0 of JNA. In this case the base url is: https://github.com/java-native-access/jna/tree/5.5.0/lib/native
-   - download the binaries for `aarch64`, `armv7`, `x86`, `x86-64`, e.g.:
-     - `android-aarch64.jar`
-     - `android-armv7.jar`
-     - `android-x86-64.jar`
-     - `android-x86.jar`
-6. Extract all downloaded JAR files and copy `libjnidispatch.so` to corresponding `jniLibs` directory
-   - You can extract the `.so` file from the jar using the `jar` command. e.g. `jar xf android-x86.jar`
-   - `libjnidispatch.so` from `android-aarch64.jar` to `jniLibs/arm64-v8a/libjnidispatch.so`
-   - `libjnidispatch.so` from `android-armv7.jar` to `jniLibs/armeabi-v7a/libjnidispatch.so`
-   - `libjnidispatch.so` from `android-x86.jar` to `jniLibs/x86/libjnidispatch.so`
-   - `libjnidispatch.so` from `android-x86-64.jar` to `jniLibs/x86_64/libjnidispatch.so`
+```groovy
+android {
+  // ...
+  packagingOptions {
+      pickFirst '**/lib/arm64-v8a/libc++_shared.so'
+      pickFirst '**/lib/arm64-v8a/libfbjni.so'
+      pickFirst '**/lib/armeabi-v7a/libc++_shared.so'
+      pickFirst '**/lib/armeabi-v7a/libfbjni.so'
+      pickFirst '**/lib/x86/libc++_shared.so'
+      pickFirst '**/lib/x86/libfbjni.so'
+      pickFirst '**/lib/x86_64/libc++_shared.so'
+      pickFirst '**/lib/x86_64/libfbjni.so'
+  }
+}
+```
 
 ### 5. Load indy library
 
@@ -114,7 +106,6 @@ public class MainActivity extends ReactActivity {
 
     try {
       Os.setenv("EXTERNAL_STORAGE", getExternalFilesDir(null).getAbsolutePath(), true);
-      System.loadLibrary("indy");
     } catch (ErrnoException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
I uploaded the Android `.aar` file to the Release 0.2.2, similarly we did with iOS dependency. Although the library still must be downloaded manually, it significantly simplifies the installation for Android. 